### PR TITLE
Fix frame skipping index in single-threaded playback

### DIFF
--- a/badApple.py
+++ b/badApple.py
@@ -109,6 +109,7 @@ while True:
     if args.threads >= 2:
         try:
             frame_idx, frame = frame_queue.get(timeout=0.1)
+            current_idx = frame_idx
         except queue.Empty:
             if stop_event.is_set() and frame_queue.empty():
                 break
@@ -118,12 +119,14 @@ while True:
         if not ret:
             break
         frame = cv2.resize(frame, (stage_w, stage_h), interpolation=cv2.INTER_AREA)
+        current_idx = frame_idx
+        frame_idx += 1
     
     # 帧跳过同步
     if args.frame_skip:
         now = time.time()
         expected_idx = int((now - t_start) * fps)
-        if frame_idx < expected_idx:
+        if current_idx < expected_idx:
             continue
 
     # 处理帧


### PR DESCRIPTION
### Motivation
- When `--frame_skip` is used with `--threads < 2`, the single-threaded read path never incremented `frame_idx`, causing `expected_idx` to become larger than the current frame index and skip all frames; the change ensures frame-skip logic can advance in non-threaded mode.

### Description
- In `badApple.py` introduce a local `current_idx`, increment `frame_idx` in the single-threaded read path, and use `current_idx` for the `frame_skip` comparison so the skip logic advances correctly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989fe96bc28832d8d2ccb9106067b94)